### PR TITLE
Add HTML Proofer for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: ruby
+install: "gem install github-pages; gem install html-proofer"
+before_script: "jekyll build"
+script: "htmlproof _site"

--- a/_chapters/ch2.md
+++ b/_chapters/ch2.md
@@ -20,7 +20,7 @@ And if you want something italicized *and* bold? You've got it: *three* asterisk
 
 So far so good. But, this is intended for the Internet. So, let's try something a little more exciting: a link to a website.
 
-A link to a website requires only slightly more markup. To include a link to this book's website, you would need to put brackets around the link, and put the URL[^2] within parentheses. So, `Tell your friends to visit [Coding for Lawyers](http://codingforlawyers.com)` would look like: Tell your friends to visit [Coding for Lawyers](https://codingforlawyers.com).
+A link to a website requires only slightly more markup. To include a link to this book's website, you would need to put brackets around the link, and put the URL[^2] within parentheses. So, `Tell your friends to visit [Coding for Lawyers](http://codingforlawyers.com)` would look like: Tell your friends to visit [Coding for Lawyers](http://codingforlawyers.com).
 
 ## An intro to HTML
 

--- a/_chapters/ch4.md
+++ b/_chapters/ch4.md
@@ -30,7 +30,7 @@ Now, let's try something a little different:
 
 <iframe src="https://trinket.io/embed/python/6c699324b4" width="100%" height="150" frameborder="0" marginwidth="0" marginheight="0" allowfullscreen></iframe>
 
-What's going on here? On line #5, we printed something to the command line. But we did two very interesting things. First, we combined two strings (remember [strings](/chapters/ch2/index.html#exhibit-1-strings)?) Second, we accessed the first string in the justices array.
+What's going on here? On line #5, we printed something to the command line. But we did two very interesting things. First, we combined two strings (remember [strings](/chapters/ch3/index.html#exhibit-1-strings)?) Second, we accessed the first string in the justices array.
 
 To access the first string in the justices array (that's called the first "index" of the array), we called `justices[0]`, not `justices[1]`. This convention of referring to the first number by "zero" instead of "one" is called ["zero-based numbering"](http://en.wikipedia.org/wiki/Zero-based_numbering). If you think this convention is odd, that's ok. But it's a "super-precedent"[^3] entitled to [*stare decisis*](http://www.law.cornell.edu/wex/stare_decisis), so you need to know it exists.
 


### PR DESCRIPTION
This pull requests adds a single `.travis.yml` which implements continuous integration checking via Travis CI. Specifically, on each pull request, the following will be checked:
- The site actually builds (e.g., no Jekyll syntax errors)
- All links are valid, including existence of in-site anchors
- All images are valid and have proper alt tags
- All scripts are valid

If all of the above passes, you'll see a big :green_heart: status icon on the pull request, letting you know you can merge with confidence ([example of a successful build](https://travis-ci.org/benbalter/codingforlawyers/builds/35435974)). If not, you'll see a :x:, indicating there's an error ([example of an erred build for this site](https://travis-ci.org/benbalter/codingforlawyers/builds/35435021)).

To note, in running it, it found two bad links, including a http/https swap, and a improper internal anchor.

@konklone, I know you were sensitive about not bloating the root with system files, but I think a single `.travis.yml` file (rather than e.g., a Gemfile + scripts) strikes a good balance as the feedback provided will be helpful for new users.

@vzvenyach If merged, you'll need to tell Travis to watch your Repo, which you can do in ~30 seconds by:
1. Go to https://travis-ci.org/profile
2. Oauth against GitHub
3. Click the On button next to this repo in the list

(note, the CI service is free and requires no maintenance once initially configured)
