### PR TITLE
Symanticize headers

### DIFF
--- a/_chapters/ch1.md
+++ b/_chapters/ch1.md
@@ -8,7 +8,7 @@ Think of regular expressions as a faster, more powerful version of "Find & Repla
 
 If you've used a database like Lexis or West or Fastcase, you've probably used a wildcard pattern such as `*` to handle this sort of thing. But, regular expressions are *even more powerful* because you can tell your computer to match many different types of patterns you're searching for, not just exact text or certain predefined wildcards. Regular expressions give you much more granular control over your patterns, and you can even use them in [Microsoft Word](http://office.microsoft.com/en-us/word-help/find-and-replace-text-by-using-regular-expressions-advanced-HA102350661.aspx).
 
-# Regular Expressions
+### Regular Expressions
 
 Regex may be intuitive for many lawyers, particularly those who were on law review.[^2] That's because citations and regular expressions are closely related. For example, lawyers know what `5 U.S.C. § 552 (2006)` is. We also know that `552 U.S. 5 (2007)` is a different thing entirely. The former is a statute enacted by Congress and codified in the United States Code. The latter is a reported decision of the Supreme Court of the United States published in the bound volumes of the United States Reports. But, let's examine them closely.
 
@@ -18,7 +18,7 @@ A minimal citation to the United States Code has four main components: (1) the t
 
 Regex allows us to assemble patterns so that a computer could recognize these patterns. Let's see how.
 
-## The building blocks of regex
+### The building blocks of regex
 
 We know that as of September 1, 2014, there are 52 titles of the United States Code.[^3] That means we can represent the first component of a citation with *either* a one-digit number (e.g., "8") or a two-digit number ("18"). In regex, we can represent any single digit as `[0-9]`. That means that regex will match any number between 0 and 9. What about *two* digits? Well, we could write `[0-9][0-9]` and that would capture `15` and `25`. Unfortunately, though, would reject `8` because `8` only has one digit.
 
@@ -42,7 +42,7 @@ Regex also allows for the shorthand `\w`, which represents any single alphanumer
 
 But, what if you wanted your pattern to match "552a" *and* "552". In other words, you don't *necessarily* want any letters to come after the numbers. To do this, the question mark metacharacter (`?`) comes into play. Here, you could simply write `552a?`, which means that the "a" is optional. By using parentheses for grouping, you can supercharge the use of the `?`. For example, you could write `(\d+)(\w+)?`, which would cover "552", "552a", and "2000bb". By grouping the repeating alphanumeric characters represented by `\w` and putting a question mark afterward, you can basically make all of the letters optional.
 
-## Assembling the United States Code
+### Assembling the United States Code
 
 Believe it or not, we know everything to represent the minimal citation to a section in the United States Code (and even more complicated ones!). Let's return to the 4 minimum components of the citation:
 
@@ -56,7 +56,7 @@ Now, let's put together the citation:
 
 Congratulations. You have constructed a relatively complex regex! And there's more good news, the road gets easier from here.
 
-## Homework
+### Homework
 
 1. Practice with a website: A few good examples are [rubular](http://www.rubular.com/) and the more feature-filled [regex 101](http://regex101.com/).
 
@@ -64,15 +64,13 @@ Congratulations. You have constructed a relatively complex regex! And there's mo
 
 3. Write a regular expression to capture a simple email address.
 
-## [Next Chapter: Markdown and HTML](/chapters/ch2/)
-
 ***
 
-## Endnotes
+### Endnotes
 
 [^1]: Many programmers would, I suspect, suggest that this is a strange place to begin. They would argue that it is not really even *coding*. It is my view that this is a proper subject for a beginning chapter. *Cf.* *Brown v. Allen*, 344 U.S. 443, 540 (1953) (Jackson, J., concurring) ("There is no doubt that if there were a super-Supreme Court, a substantial proportion of our reversals of state courts would also be reversed. We are not final because we are infallible, but we are infallible only because we are final."). Plus, by the time you are done with this chapter, you can impress your coding friends that you know basic "regex". A word of caution, the universe of non-coders who will be impressed your knowledge of regex is rather small.
 
-[^2]: A quick review of my curriculm vitae demonstrates that I was not on law review in law school. I am using many footnotes to compensate.
+[^2]: A quick review of my curriculum vitae demonstrates that I was not on law review in law school. I am using many footnotes to compensate.
 
 [^3]: Editorial Reclassification, Title 52, United States Code, *available online at* [http://uscode.house.gov/editorialreclassification/t52/index.html](http://uscode.house.gov/editorialreclassification/t52/index.html).
 

--- a/_chapters/ch2.md
+++ b/_chapters/ch2.md
@@ -8,7 +8,7 @@ Before diving into Markdown, and at the risk of alienating many readers, I want 
 
 Markdown, when it gets right down to it, is just a way to "mark up" text and describe certain things to a computer, so the computer knows what is important to the eventual reader. That's it. It's a simple, powerful way of making all kinds of marks around plain text in order to make the text more useable.
 
-## An Intro to Markdown Syntax[^1]
+### An Intro to Markdown Syntax[^1]
 
 Let's say you want to italicize a sentence in a document. In a word processor, you would highlight the sentence and either press Ctrl-I or the little "italics" icon. I suppose there may be other ways, but that's the conventional one.
 
@@ -22,7 +22,7 @@ So far so good. But, this is intended for the Internet. So, let's try something 
 
 A link to a website requires only slightly more markup. To include a link to this book's website, you would need to put brackets around the link, and put the URL[^2] within parentheses. So, `Tell your friends to visit [Coding for Lawyers](http://codingforlawyers.com)` would look like: Tell your friends to visit [Coding for Lawyers](https://codingforlawyers.com).
 
-## An intro to HTML
+### An intro to HTML
 
 Now that you understand a bit of Markdown syntax, we'll turn attention briefly to HTML. As it turns out, the main *reason* Markdowneven  exists  is that writing HTML is annoying. Now, you may be asking, "why would anyone write HTML?" And perhaps before that, you may be asking, "what is HTML?"
 
@@ -40,7 +40,7 @@ To define the link's target, you define an "attribute" for the tag. Specifically
 
 If you copied and pasted this exact phrase into a plain text file, saved it as "test.html", and opened that file in a browser, you would have a working HTML document. Neat, huh?
 
-## More syntax in Markdown and HTML
+### More syntax in Markdown and HTML
 
 Recognizing that Markdown and HTML are closely related, let's explore some more Markdown and HTML syntax.
 
@@ -108,7 +108,7 @@ Take note that HTML describes the heading as `<h1>` and `<h2>`. This is baked in
 
 Try to copy and paste that HTML into a plain text file, save it as "ecf_va.html", and open the file in the browser. Voila, you have  a working HTML file with a link to the Virgina federal courts' ECF sites.
 
-## Conclusion
+### Conclusion
 
 At this point, you should have a sense of how Markdown and HTML look and interact with each other. You should take time to learn the Markdown syntax from the official specification. There are a few other use cases -- especially blockquotes -- in Markdown that you should be aware of.
 
@@ -116,14 +116,9 @@ Getting to fully understand HTML, on the other hand, can be much more involved. 
 
 If you stopped here, you would be able to meaningfully build beautiful websites using Markdown. But you won't stop here, because it keeps gets better...
 
-## [Previous Chapter: Regular Expressions](/chapters/ch1/)
-
-## [Next Chapter: Data Types](/chapters/ch3/)
-
-
 ***
 
-## Endnotes
+### Endnotes
 
 [^1]: At some point, you should read the entire Markdown syntax documentation. It is very short, but covers a significant amount of ground. You should also know that there are many different "flavors" of Markdown. A flavor is a subtle variation of Markdown to provide specific features, such as footnotes.
 

--- a/_chapters/ch3.md
+++ b/_chapters/ch3.md
@@ -8,25 +8,25 @@ Think of data types like exhibits at trial. You need exhibits to prove facts at 
 
 With that analogy firmly set, let's introduce these exhibits.
 
-## Exhibit 1: Strings
+### Exhibit 1: Strings
 
 Of all of the data types, lawyers should feel most comfortable with strings. That's because a string is nothing but a collection of characters, typically set off by quotation marks. So, for example: `"this is a string"` and `"We the People"` are both strings. Many programming languages allow for using single quotes, as well, such that `"this is a string"` and `'this is a string'` are equal to each other.
 
-## Exhibit 2: Integers
+### Exhibit 2: Integers
 
 Integers are just what you'd expect them to be. They are whole numbers, positive and negative. `1` is an integer. `2` is an integer. `three` is NOT an integer, however, and neither is `1.5`.
 
-## Exhibit 3: Floats
+### Exhibit 3: Floats
 
 Just a moment ago, when looking at integers Exhibit 2, we observed that `1.5` is not an integer. Instead, it is considered to be a "float", because it has a  "floating decimal". The following are all examples of floats: `3.14`, `2.1828`, and `0.0001`. As one reader ([@jeremybowers](https://twitter.com/jeremybowers)) observed, recording a billable hour can often involve a float: `0.1` of a billable hour corresponds to 6 minutes.
 
-## Exhibit 4: Booleans
+### Exhibit 4: Booleans
 
 Sometimes, you just want a witness to answer "yes" or "no". Although it can be an art to get a witness to do this, it is trivial to ask a computer to do it. That's because of booleans. A boolean is either `True` or `False`.
 
 Your honor, may we approach?
 
-## A brief sidebar about variables
+### A brief sidebar about variables
 
 The power of data types, like exhibits, is that once they've been properly introduced, you can refer to them directly. Computers do this by "defining a variable". Different programming languages have different ways of doing this, but the concept is always the same. You define the variable and then you can use it. For the purpose of this chapter, we're going to use the syntax associated with the Python programming language, primarily because it is very simple.
 
@@ -36,7 +36,7 @@ Let's go ahead and define a variable "case_name" to be the string "Marbury v. Ma
 
 Couldn't be simpler, right? Ok, sidebar over.
 
-## Exhibit 5: Array
+### Exhibit 5: Array
 
 An array, despite its total simplicity, is a surprisingly powerful data type. An array is a list of data. That's it.  Here's an example of an array:
 
@@ -44,7 +44,7 @@ An array, despite its total simplicity, is a surprisingly powerful data type. An
 
 Piece of cake? Good.
 
-## Exhibit 6: Objects
+### Exhibit 6: Objects
 
 As a thought experiment, try to describe a music album. You might describe the group that made the album. You might list the names of the tracks. You might describe the year that the album was released.
 
@@ -70,9 +70,6 @@ scotus = {
 
 The reason objects are special is that you can access the attributes in a powerful way. So, for example, if you asked the computer what `scotus["name"]` is, the computer would say: `"Supreme Court of the United States"`.
 
-# Conclusion
+### Conclusion
 
 Throughout the rest of this book, we'll spend a lot of time manipulating these data types. Remember, they are just exhibits. The real power in coding is using these exhibits to make your case. In the next chapter, we'll take a closer look at arrays and write our first script.
-
-## [Previous Chapter: Markdown and HTML](/chapters/ch2/)
-## [Next Chapter: Using Arrays](/chapters/ch4/)

--- a/_chapters/ch4.md
+++ b/_chapters/ch4.md
@@ -10,7 +10,7 @@ justices = ["Roberts","Scalia","Kennedy","Thomas","Ginsburg","Breyer","Alito","S
 
 Let's try a few things in python.[^1]
 
-## Getting Started with Arrays
+### Getting Started with Arrays
 
 Click the "run" button below:
 
@@ -24,7 +24,7 @@ What did we do here? Let's examine line by line:
 
 You'll note that on lines 1, 4, and 7, we have a little `#` symbol at the beginning of the line. This is a way of telling the program that everything after it is a "comment". Think of this as a "note to self" (or, more generously, a note to anyone else reading the source code.)[^2]
 
-## Numbering, Types, and Arrays
+### Numbering, Types, and Arrays
 
 Now, let's try something a little different:
 
@@ -38,7 +38,7 @@ Now, getting back to the script above, on line #8, we took advantage of the `len
 
 In line # 11, we did something really strange. We wrote `str(len(justices))`. Why did we do that? Well, it is because some languages don't let you mix data types. A string can be added to another string. An integer may be substracted from another string. But an integer may not be combined to two other strings. So, we used the `str` function to convert `len(justices)` from an integer, 9, to a string, "9".
 
-## A nested array and a loop?
+### A nested array and a loop?
 
 Now let's do one last exercise with arrays, and this one will take a few minutes but will propel you to the next level of coding. So prepare yourself and soak it in:
 
@@ -60,12 +60,9 @@ Finally, we "step through" the iterator one-by-one.
 
 In the end, you have a Markdown-ready result of the Virginia federal courts. And you did it "programmatically". This is progress.
 
-## Conclusion
+### Conclusion
 
 Arrays are, in many respects, seductively simple. They are lists: no more, no less.[^7] But when you master arrays, worlds of data become accessible and manipulable in ways that seemed totally impossible before. So, go ahead and play with the interactive scripts above. Maybe even consider [reading more about what arrays can do in python](https://docs.python.org/2/tutorial/datastructures.html).[^8] Congratulations on making it this far!
-
-## [Previous Chapter: Data Types](/chapters/ch3/)
-## [Next Chapter: Conditional Logic](/chapters/ch5/)
 
 ***
 

--- a/_chapters/ch5.md
+++ b/_chapters/ch5.md
@@ -4,7 +4,7 @@ title: "Chapter 5: Conditional Logic"
 
 Computers, in some respects, are like hostile witnesses on cross-examination. You don't want to ask them open-ended questions, you want to lead the witness. But, unlike human witnesses, computers will always tell you the answer to your question.[^1] In coding, this use of leading questions is referred to "conditional testing".[^2] In this chapter, we'll discuss some of the "questions" you can ask a computer to answer and examine how the computer will answer.
 
-## Tests
+### Tests
 
 Generally there are six questions that a computer is trained to answer:
 
@@ -19,7 +19,7 @@ In the above "thing" is put in quotes because the thing which is being compared 
 
 It is bad form to ask a hostile witness "About how fast would you say you were going?" Instead, you might ask: "Did you drive faster than 55 mph?" In conditional syntax, this would be `speed > 55`. If the computer answers `True`, then you might have your negligence *per se* case in the bag.  
 
-## If
+### If
 
 Since we are talking about witnesses at trial, it's helpful to think about the rules of evidence. Typically, the rules of evidence follow a specific pattern: `if` the evidence you present to a judge meets the test established by the rules of evidence in your jurisdiction `then` the judge shall allow it into evidence. In programming, `if` tests work the same way.
 
@@ -37,7 +37,7 @@ In programming, like in trial, you can evaluate the truth of a statement to prov
 
 One tricky item to note about the above code is to know the difference between what the "=" symbols in the first and second line are doing. In the first line the one "=" is telling the computer to assign the variable `hearsay` with the value `True`. In the second line the two "==" are telling the computer to test whether the two "things" on either side of the test are equal.
 
-## Else - If
+### Else - If
 
 Many times when you are programming you will want to make conditional tests which are more complex than the above example. In these instances often you want to tell the computer to first perform one test, and if that one is not successful to try another test. The first test is an `if` test which is covered above. The second test is usually called an `else-if` test. In other words, else (meaning the previous test failed) ... if (perform this test). Let's take a look at another example.
 
@@ -59,7 +59,7 @@ Then, we run it through our first test: is `relevant` the same as `False`? Well,
 
 But, if `relevant` were `False` in the example, the computer would skip over the second test. That is because the `else if` test only is triggered if the `if` test fails.
 
-## Else
+### Else
 
 When you are making strings of conditionals sometimes you want to tell the computer that if all the tests pass then what it should do. So, for the example above, what happens if the prejudicial effect did *not* weigh the probative value? To program that, we use a `else` statement.
 
@@ -80,14 +80,11 @@ else:
 
 In the above code we have switched the values of `probative_effect` and `prejudicial_effect` but otherwise kept most the code the same. In the last two lines, however, we  added an `else` statement. Unlike `if` and `else-if`, `else` does not contain a test. This is because `else` means if all the other tests have failed, do this.
 
-## Conclusion
+### Conclusion
 
 Conditionals are a way to test whether things are true or not and if they are true then to perform some action. In general these can be thought of similar to how the rules of evidence, if the tests are passed will allow evidence into the record but if they are not passed will not allow evidence into the record.
 
 `If` you have made it this far, you are to be congratulated. In the next chapter, we will get a preview of the real magic of programming: it can save you time and get you more consistent results. Your clients will thank you while you kick up your feet and let the computer do the hard stuff. Ok, so that may be a bit of an exaggeration, but you'll be a better lawyer nonetheless. Read on.
-
-## [Previous Chapter: Using Arrays](/chapters/ch4/)
-## [Next Chapter: DRY and Functions](/chapters/ch6/)
 
 ***
 

--- a/_chapters/ch6.md
+++ b/_chapters/ch6.md
@@ -2,7 +2,7 @@
 title: "Chapter 6: DRY and Functions"
 ---
 
-## The DRY principle
+### The DRY principle
 
 From time to time, developers will refer to something called DRY, and lawyers would do well to embrace it when appropriate. DRY stands for "Don't Repeat Yourself" and is an important, deeply embedded cultural norm for developers. Note, this norm is *not* deeply  embedded for most lawyers, at least formally. In fact, some lawyers are openly hostile to the DRY principle. Let me give you an example. In the world of technology, using an acronym or an initialism to describe something you say a lot is a no-brainer. It is *completely normal* for a programmer to ask "Can I get the JSON or XML through a REST API?"[^1] By contrast, when *lawyers* use abbreviations, they are open to criticism. Consider this concurring opinion from a senior federal appellate court judge:
 
@@ -14,7 +14,7 @@ So, why should lawyers care about DRY? The answer is simple: used correctly, DRY
 
 DRY is the same principle that underlies form pleadings and standard contract provisions. It is the reason that you reuse major chunks of your "standard of review" section in your briefs. In other words, you likely already have DRY in your practice, you just never knew that it had a name. It does, and I won't repeat it.
 
-## Functions
+### Functions
 
 A core part of implementation for DRY in code is the use of "functions". You use functions to have computers *do* something. You can define a function as simple as "say hello" or as complicated as "cure cancer".[^4] When you "call" a function, you are telling the computer to do the defined thing. With that understanding, let's define a simple function in Javascript. [^5]
 
@@ -54,13 +54,11 @@ console.log(fre(403))
 
 The script above  has several parts, so let's examine them one by one. First, we defined a function called "fre." We define the function to accept, as an input, a "rule." Next, we check to see whether `rule` is equal to `403`. If it is, we "return" the string associated with Rule 403 of the Federal Rules of Evidence. If the rule is not `403`, we return a different string. Finally, we call `fre`, pass `403` as an argument,[^6] and print the retured value of the function to the console.[^7]
 
-## Conclusion
+### Conclusion
 
 The `fre` function above illustrates a use case that I suspect many lawyers experience. You need to quote a rule in a brief, so you end up copying and pasting the rule from a PDF file and into the document. But that would violate DRY, since you already know the associated rule, you should just be able to type in the number and the rest happens magically. If you start thinking about functions in this way, you can probably imagine many routines that would make your work more enjoyable.
 
 In theory, you could define the `fre` function above with a bunch of if-else statements and return the text of any rule of evidence based on the rule number. But that would be a lot of if-else statements. Fortunately, in the next chapter, we'll learn a smarter way to do it, using "objects".
-
-## [Previous Chapter: Conditional Logic](/chapters/ch5/)
 
 ***
 

--- a/_layouts/chapter.html
+++ b/_layouts/chapter.html
@@ -3,3 +3,20 @@ layout: default
 ---
 
 {{ content }}
+
+{% for chapter in site.chapters %}
+  {% if chapter.path == page.path %}
+    {% assign next = forloop.index %}
+    {% assign previous = forloop.index0 | minus:1 %}
+    {% assign count = forloop.length %}
+  {% endif %}
+{% endfor %}
+
+<ul class="nav-links">
+{% if next < count %}
+  <li><a class="next" href="{{ site.chapters[next].url }}">Next chapter: {{ site.chapters[next].title }}</a></li>
+{% endif %}
+{% if previous >= 0 %}
+  <li><a class="previous" href="{{ site.chapters[previous].url }}">Previous chapter: {{ site.chapters[previous].title }}</a></li>
+{% endif %}
+</ul>

--- a/assets/style.css
+++ b/assets/style.css
@@ -13,6 +13,11 @@ body {
 	float: right;
 }
 
+.nav-links li { list-style: none; font-weight: bold; }
+.nav-links { padding-left: 0; clear: both; height: 1em; }
+.nav-links .next { float: right; }
+.nav-links .previous { float: left; }
+
 // Pygments
 
 .hll { background-color: #ffffcc }


### PR DESCRIPTION
Fixes #18.

This moves all in-document headers to H3s or less (from h1s, h2s, and h3s), and moves navigation to a UL, rather than being dual H3s.

The navigation links are now automatically generated (separating content from presentation) and floated right/left for next previous.
## Before

![screen shot 2014-09-16 at 10 31 53 am](https://cloud.githubusercontent.com/assets/282759/4288706/3a6d16c0-3dae-11e4-973c-7367fc6ea7a5.png)
## After

![screen shot 2014-09-16 at 10 27 41 am](https://cloud.githubusercontent.com/assets/282759/4288684/0e172a48-3dae-11e4-9f7a-e8786ef9a338.png)
